### PR TITLE
Use ⌥ ← and ⌥→ to jump forwards / backwards words in iTerm 2

### DIFF
--- a/iterm2/com.googlecode.iterm2.plist
+++ b/iterm2/com.googlecode.iterm2.plist
@@ -519,9 +519,9 @@
 				<key>0xf702-0x280000</key>
 				<dict>
 					<key>Action</key>
-					<integer>11</integer>
+					<integer>10</integer>
 					<key>Text</key>
-					<string>0x1b 0x1b 0x5b 0x44</string>
+					<string>b</string>
 				</dict>
 				<key>0xf703-0x220000</key>
 				<dict>
@@ -547,9 +547,9 @@
 				<key>0xf703-0x280000</key>
 				<dict>
 					<key>Action</key>
-					<integer>11</integer>
+					<integer>10</integer>
 					<key>Text</key>
-					<string>0x1b 0x1b 0x5b 0x43</string>
+					<string>f</string>
 				</dict>
 				<key>0xf704-0x20000</key>
 				<dict>


### PR DESCRIPTION
@partyschaum
